### PR TITLE
Fix inverse determinant and add test

### DIFF
--- a/src/affine.rs
+++ b/src/affine.rs
@@ -574,7 +574,7 @@ impl Not for Affine {
             d: rd,
             e: re,
             f: -sc * rd - sf * re,
-            determinant: Some(1.0 / idet),
+            determinant: Some(idet),
         })
     }
 }
@@ -745,6 +745,14 @@ mod tests {
         let p = (5.0, 5.0);
         assert_eq!(c1 * p, c2 * p);
         assert_eq!(c1 * p, (20.0, 35.0));
+    }
+
+    #[test]
+    fn test_inversion_determinant() {
+        let s = Affine::scale(2.0, Some(3.0));
+        let inv = (!s).unwrap();
+        let expected = 1.0 / s.determinant();
+        assert!((inv.determinant() - expected).abs() < get_epsilon());
     }
 }
 


### PR DESCRIPTION
## Summary
- correct determinant value for inverse matrices
- test the determinant of inverses

## Testing
- `cargo fmt -- --check` *(fails: rustfmt not installed)*
- `cargo test` *(fails: could not fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_684addc79d708321bb19b62c090404a7