### PR TITLE
Support isize point multiplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ fn main() {
     let result = translation * point;
     println!("Translated point: {:?}", result); // (11.0, 21.0)
 
+    // Transform an integer point
+    let ipoint = (1isize, 1isize);
+    let iresult = translation * ipoint;
+    println!("Translated point: {:?}", iresult); // (11, 21)
+
     // Compose transformations (applied right to left)
     let composite = translation * rotation * scale;
     let transformed = composite * point;

--- a/README.zh.md
+++ b/README.zh.md
@@ -27,6 +27,11 @@ fn main() {
     let result = translation * point;
     println!("Translated point: {:?}", result); // (11.0, 21.0)
 
+    // 变换整数点
+    let ipoint = (1isize, 1isize);
+    let iresult = translation * ipoint;
+    println!("Translated point: {:?}", iresult); // (11, 21)
+
     // 组合变换（从右到左应用）
     let composite = translation * rotation * scale;
     let transformed = composite * point;

--- a/src/affine.rs
+++ b/src/affine.rs
@@ -544,6 +544,28 @@ impl Mul<(f64, f64)> for &Affine {
     }
 }
 
+/// Implement matrix multiplication for Affine transform and integer point.
+impl Mul<(isize, isize)> for Affine {
+    type Output = (isize, isize);
+
+    #[inline]
+    fn mul(self, point: (isize, isize)) -> (isize, isize) {
+        let (x, y) = self.transform_vector((point.0 as f64, point.1 as f64));
+        (x.round() as isize, y.round() as isize)
+    }
+}
+
+/// Implement matrix multiplication for reference to Affine and integer point.
+impl Mul<(isize, isize)> for &Affine {
+    type Output = (isize, isize);
+
+    #[inline]
+    fn mul(self, point: (isize, isize)) -> (isize, isize) {
+        let (x, y) = self.transform_vector((point.0 as f64, point.1 as f64));
+        (x.round() as isize, y.round() as isize)
+    }
+}
+
 /// Implement inversion (~) operator for Affine transform.
 impl Not for Affine {
     type Output = Result<Self, AffineError>;
@@ -698,6 +720,14 @@ mod tests {
         let p = (5.0, 5.0);
         let result = t * p;
         assert_eq!(result, (15.0, 25.0));
+    }
+
+    #[test]
+    fn test_translation_isize() {
+        let t = Affine::translation(10.0, 20.0);
+        let p = (5isize, 5isize);
+        let result = t * p;
+        assert_eq!(result, (15isize, 25isize));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add integer point multiplication implementations
- test integer translation
- document integer point usage in README files

## Testing
- `cargo test --locked --offline` *(fails: no matching package named `thiserror` found)*

------
https://chatgpt.com/codex/tasks/task_e_685413055fa08321ad92c425d1729789