### PR TITLE
Update from_gdal

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,7 @@ fn main() {
 ```rust
 // Import from GDAL GeoTransform format
 let gdal_params = [100.0, 1.0, 0.0, 200.0, 0.0, -1.0];
-let transform = Affine::from_gdal(
-    gdal_params[0], gdal_params[1], gdal_params[2],
-    gdal_params[3], gdal_params[4], gdal_params[5]
-);
+let transform = Affine::from_gdal(&gdal_params);
 
 // Export to GDAL format
 let (c, a, b, f, d, e) = transform.to_gdal();

--- a/README.zh.md
+++ b/README.zh.md
@@ -50,10 +50,7 @@ fn main() {
 ```rust
 // 从 GDAL GeoTransform 格式导入
 let gdal_params = [100.0, 1.0, 0.0, 200.0, 0.0, -1.0];
-let transform = Affine::from_gdal(
-    gdal_params[0], gdal_params[1], gdal_params[2],
-    gdal_params[3], gdal_params[4], gdal_params[5]
-);
+let transform = Affine::from_gdal(&gdal_params);
 
 // 导出为 GDAL 格式
 let (c, a, b, f, d, e) = transform.to_gdal();

--- a/src/affine.rs
+++ b/src/affine.rs
@@ -131,7 +131,8 @@ impl Affine {
 
     /// Create a transformation from GDAL's GetGeoTransform() coefficient order.
     #[inline]
-    pub fn from_gdal(c: f64, a: f64, b: f64, f: f64, d: f64, e: f64) -> Self {
+    pub fn from_gdal(coeffs: &[f64; 6]) -> Self {
+        let [c, a, b, f, d, e] = *coeffs;
         Self::new(a, b, c, d, e, f)
     }
 
@@ -783,6 +784,13 @@ mod tests {
         let inv = (!s).unwrap();
         let expected = 1.0 / s.determinant();
         assert!((inv.determinant() - expected).abs() < get_epsilon());
+    }
+
+    #[test]
+    fn test_from_to_gdal() {
+        let params = [100.0, 1.0, 0.0, 200.0, 0.0, -1.0];
+        let affine = Affine::from_gdal(&params);
+        assert_eq!(affine.to_gdal(), (100.0, 1.0, 0.0, 200.0, 0.0, -1.0));
     }
 }
 


### PR DESCRIPTION
## Summary
- update `Affine::from_gdal` to accept a `&[f64; 6]` array
- update GDAL documentation examples
- add regression test for new API

## Testing
- `cargo test --quiet` *(fails: failed to download index)*

------
https://chatgpt.com/codex/tasks/task_e_685416e17c28832183286ba71d07afdd